### PR TITLE
Update inheritance of several Mobjects in m_array.py

### DIFF
--- a/src/manim_data_structures/m_array.py
+++ b/src/manim_data_structures/m_array.py
@@ -11,7 +11,7 @@ from .m_enum import MArrayDirection, MArrayElementComp
 
 
 @utils.exclude_from_deepcopy("_MArrayElement__scene")
-class MArrayElement(VGroup):
+class MArrayElement(VMobject):
     """A class that represents an array element.
 
     Parameters

--- a/src/manim_data_structures/m_array.py
+++ b/src/manim_data_structures/m_array.py
@@ -1725,7 +1725,7 @@ class MArray(VGroup):
 
 
 @utils.exclude_from_deepcopy("_MArrayPointer__scene", "_MArrayPointer__arr")
-class MArrayPointer(VGroup):
+class MArrayPointer(VMobject):
     """A class that represents a pointer.
 
     Parameters

--- a/src/manim_data_structures/m_array.py
+++ b/src/manim_data_structures/m_array.py
@@ -2190,7 +2190,7 @@ class MArrayPointer(VMobject):
 
 
 @utils.exclude_from_deepcopy("_MArraySlidingWindow__scene", "_MArraySlidingWindow__arr")
-class MArraySlidingWindow(VGroup):
+class MArraySlidingWindow(VMobject):
     """A class that represents a sliding window
 
     Parameters


### PR DESCRIPTION
<!-- Thank you for contributing to Manim Data Structures! Learn more about the process in our contributing guidelines: https://github.com/ufosc/manim-data-structures/blob/main/CONTRIBUTING.md -->

## Overview: What does this pull request change?
<!-- If there is more information than the PR title that should be added to our release changelog, add it in the following changelog section. This is optional, but recommended for larger pull requests. -->
<!--changelog-start-->
This pull request updates the MArrayElement, MArrayPointer, and MArraySlidingWindow Mobjects in m_array.py to inherit from VMobject instead of VGroup.
<!--changelog-end-->

## Motivation and Explanation: Why and how do your changes improve the library?
<!-- Optional for bugfixes, small enhancements, and documentation-related PRs. Otherwise, please give a short reasoning for your changes. -->
Changing the inheritance of the Mobjects from VGroup to VMobject will help the implemented Mobjects avoid exhibiting strange behaviors when using operators. I changed the inheritance of the MArrayElement, MArrayPointer, and MArraySlidingWindow Mobjects because the functionality of these Mobjects didn't depend on any of the methods and operators provided by VGroup.

## Further Information and Comments
<!-- If applicable, put further comments for the reviewers here. -->



<!-- Thank you again for contributing! Do not modify the lines below, they are for reviewers. -->
## Reviewer Checklist
- [ ] The PR title is descriptive enough for the changelog, and the PR is labeled correctly
- [ ] If applicable: newly added code segments are adequately covered by tests
- [ ] If applicable: newly added non-private functions and classes have a docstring including a short summary and a PARAMETERS section
